### PR TITLE
Solved a KeyError at line 92 of views.py

### DIFF
--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -66,8 +66,8 @@ def setup(request, template='socialregistration/setup.html',
                 user = form.profile.authenticate()
                 login(request, user)
 
-                del request.session['socialregistration_user']
-                del request.session['socialregistration_profile']
+                if 'socialregistration_user' in request.session: del request.session['socialregistration_user']
+                if 'socialregistration_profile' in request.session: del request.session['socialregistration_profile']
 
                 return HttpResponseRedirect(_get_next(request))
 
@@ -89,8 +89,8 @@ def setup(request, template='socialregistration/setup.html',
         login(request, user)
 
         # Clear & Redirect
-        del request.session['socialregistration_user']
-        del request.session['socialregistration_profile']
+        if 'socialregistration_user' in request.session: del request.session['socialregistration_user']
+        if 'socialregistration_profile' in request.session: del request.session['socialregistration_profile']
         return HttpResponseRedirect(_get_next(request))
 
 if has_csrf:


### PR DESCRIPTION
I have my project configured to create automatically an user in the setup with SOCIALREGISTRATION_GENERATE_USERNAME

When a user is created, If the user was loged in in Facebook, everything was ok, but if he didn't, I always got a keyError al line 92 because "socialregistration_user" was not found in the request.session dictionary.

To solve this I just check before deleting, and now everything is working fine.
