### PR TITLE
Fix for issue 51 and support for Facebook Extended Permissions

### DIFF
--- a/socialregistration/middleware.py
+++ b/socialregistration/middleware.py
@@ -21,8 +21,9 @@ class FacebookMiddleware(object):
         """
         
         fb_user = facebook.get_user_from_cookie(request.COOKIES,
-            settings.FACEBOOK_API_KEY, settings.FACEBOOK_SECRET_KEY)
+            settings.FACEBOOK_APP_ID, settings.FACEBOOK_SECRET_KEY)
 
         request.facebook = Facebook(fb_user)
         
         return None
+

--- a/socialregistration/templates/socialregistration/facebook_button.html
+++ b/socialregistration/templates/socialregistration/facebook_button.html
@@ -1,12 +1,6 @@
-{% load socialregistration_tags %}
 {% comment %}
-<fb:login-button autologoutlink="true" perms="email,user_birthday,status_update,publish_stream"></fb:login-button>
+<fb:login-button autologoutlink="true" perms="{{ facebook_extended_permissions }}"></fb:login-button>
 {% endcomment %}
 
-<form class="connect-button" name="login" method="post" action="{% if logged_in %}{% url facebook_connect %}{% else %}{% url facebook_login %}{% endif %}">
-{% social_csrf_token %}
-{% if next %}
-    <input type="hidden" name="next" value="{{ next }}" />
-{% endif %}
-<input type="image" onclick="facebookConnect(this.form);return false;" src="http://static.ak.fbcdn.net/images/fbconnect/login-buttons/connect_light_large_long.gif" />
-</form>
+<a id="facebookConnect" href="javascript://"><img src="http://static.ak.fbcdn.net/images/fbconnect/login-buttons/connect_light_large_long.gif" /></a>
+

--- a/socialregistration/templates/socialregistration/facebook_js.html
+++ b/socialregistration/templates/socialregistration/facebook_js.html
@@ -1,15 +1,37 @@
-<div id="fb-root">
-    {% if is_https %}<script src="https://connect.facebook.net/en_US/all.js"></script>{% else %}<script src="http://connect.facebook.net/en_US/all.js"></script>{% endif %}
-</div>
+<div id="fb-root"></div>
 <script>
-  // initialize the library with the API key
-  FB.init({ apiKey: '{{ facebook_api_key }}', status: true, cookie: true, xfbml: true});
+    // initialize the library with the API key
+    window.fbAsyncInit = function(){
+        FB.init({appId: '{{ facebook_app_id }}', status: true, cookie: true, xfbml: true});
 
-  function facebookConnect(form){
-      function handleResponse(response){
-          form.submit();
-      }
-      FB.login(handleResponse/*,{perms:'publish_stream,sms,offline_access,email,read_stream,status_update,etc'}*/);
-  }
+        var facebookConnect = document.getElementById('facebookConnect');
+        facebookConnect.onclick = function() {
+            FB.login(function(response){
+                if (response.session) {
+                    {% comment %}
+                    Use this to check if user granted the extended permissions
+                    if (response.perms) {
+                    } else {
+                    }
+                    {% endcomment %}
 
+                    {% if logged_in %}
+                    window.location = '{% url facebook_connect %}{% if next %}?next={{ next|urlencode }}{% endif %}';
+                    {% else %}
+                    window.location = '{% url facebook_login %}{% if next %}?next={{ next|urlencode }}{% endif %}';
+                    {% endif %}
+                } else {
+                    // Error with the login
+                }
+            }, {perms: '{{ facebook_extended_permissions }}'});
+        }
+    };
+    
+    // Download the library asynchronously
+    (function() {
+        var e = document.createElement('script'); e.async = true;
+        e.src = document.location.protocol + '//connect.facebook.net/en_US/all.js';
+        document.getElementById('fb-root').appendChild(e);
+    }());
 </script>
+

--- a/socialregistration/templatetags/facebook_tags.py
+++ b/socialregistration/templatetags/facebook_tags.py
@@ -1,20 +1,25 @@
 from django import template
 from django.conf import settings
-from socialregistration.utils import _https
 
 register = template.Library()
 
-@register.inclusion_tag('socialregistration/facebook_js.html')
-def facebook_js():
-    return {'facebook_api_key' : settings.FACEBOOK_API_KEY, 'is_https' : bool(_https())}
+FACEBOOK_APP_ID = getattr(settings, 'FACEBOOK_APP_ID', None)
+FACEBOOK_EXTENDED_PERMISSIONS = getattr(settings, 'FACEBOOK_EXTENDED_PERMISSIONS', [])
+
+@register.inclusion_tag('socialregistration/facebook_js.html', takes_context=True)
+def facebook_js(context):
+    if not 'request' in context:
+        raise AttributeError, 'Please add the ``django.core.context_processors.request`` context processors to your settings.TEMPLATE_CONTEXT_PROCESSORS set'
+    return {'next': context['next'] if 'next' in context else None,
+            'request': context['request'],
+            'logged_in': context['request'].user.is_authenticated(),
+            'facebook_app_id' : FACEBOOK_APP_ID,
+            'facebook_extended_permissions': ','.join(FACEBOOK_EXTENDED_PERMISSIONS)}
 
 @register.inclusion_tag('socialregistration/facebook_button.html', takes_context=True)
 def facebook_button(context):
     if not 'request' in context:
         raise AttributeError, 'Please add the ``django.core.context_processors.request`` context processors to your settings.TEMPLATE_CONTEXT_PROCESSORS set'
-    logged_in = context['request'].user.is_authenticated()
-    if 'next' in context:
-        next = context['next']
-    else:
-        next = None
-    return dict(next=next, logged_in=logged_in, request=context['request'])
+    return {'request': context['request'],
+            'facebook_extended_permissions': ','.join(FACEBOOK_EXTENDED_PERMISSIONS)}
+

--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -189,9 +189,7 @@ def twitter(request, account_inactive_template='socialregistration/account_inact
     if user is None:
         profile = TwitterProfile(twitter_id=user_info['id'])
         user = User()
-        user_full_name = user_info['name'].split(' ')
-        user.first_name = user_full_name[0]
-        user.last_name = ' '.join(user_full_name[1:])
+        user.first_name, user.last_name = user_info['name'].split(' ', 1)
         # FIXME Twitter does not provide a way to get the user email address
         user.email = "%s@twitter" % user_info['screen_name']
         request.session['socialregistration_profile'] = profile
@@ -293,7 +291,11 @@ def openid_callback(request, template='socialregistration/openid.html',
 
         user = authenticate(identity=identity)
         if user is None:
-            request.session['socialregistration_user'] = User()
+            user = User()
+            user_info = client.get_user_info()
+            user.first_name, user.last_name = user_info.get('fullname', ' ').split(' ', 1)
+            user.email = user_info.get('email', '')
+            request.session['socialregistration_user'] = user
             request.session['socialregistration_profile'] = OpenIDProfile(
                 identity=identity
             )

--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -189,6 +189,11 @@ def twitter(request, account_inactive_template='socialregistration/account_inact
     if user is None:
         profile = TwitterProfile(twitter_id=user_info['id'])
         user = User()
+        user_full_name = user_info['name'].split(' ')
+        user.first_name = user_full_name[0]
+        user.last_name = ' '.join(user_full_name[1:])
+        # FIXME Twitter does not provide a way to get the user email address
+        user.email = "%s@twitter" % user_info['screen_name']
         request.session['socialregistration_profile'] = profile
         request.session['socialregistration_user'] = user
         request.session['next'] = _get_next(request)


### PR DESCRIPTION
Hi.
I'm working to autofill the user information [1] when logging in with socialregistration.

The easiest one is with Facebook, so I give it a try.

First, I fixed the issue 51 (use FACEBOOK_APP_ID instead of FACEBOOK_API_KEY on FB.init and middleware).

Then, I added the setting FACEBOOK_EXTENDED_PERMISSIONS, to keep permissions centralized and check if e-mail permission was requested, and modified the 'facebook_login' view to grab these infos with the Facebook GraphAPI and autofill the newly created User instance.
Joined with a comma separator and added the FACEBOOK_EXTENDED_PERMISSIONS to the template tags 'facebook_js' and 'facebook_button' with the context name of 'facebook_extended_permissions' to be used in the Facebook JS and HTML login button.

I think that the fix for the issue 51 and the other modifications should be in separated commits, but I'm still learning Git and ended up commiting it together =/

Sorry for any english mistakes, not my main language.

[1] Autofill fields: first_name, last_name and email (email only used if 'email' in FACEBOOK_EXTENDED_PERMISSIONS and in the request.facebook.graph).
