### PR TITLE
Support offline_access facebook permission

### DIFF
--- a/socialregistration/middleware.py
+++ b/socialregistration/middleware.py
@@ -8,6 +8,7 @@ class Facebook(object):
         else:
             self.uid = user['uid']
             self.user = user
+            self.access_token = user['access_token']
             self.graph = facebook.GraphAPI(user['access_token'])
 
 
@@ -19,9 +20,25 @@ class FacebookMiddleware(object):
         You might want to use this if you don't feel confortable with the 
         javascript library.
         """
-        
         fb_user = facebook.get_user_from_cookie(request.COOKIES,
-            settings.FACEBOOK_API_KEY, settings.FACEBOOK_SECRET_KEY)
+          settings.FACEBOOK_API_KEY, settings.FACEBOOK_SECRET_KEY)
+
+        if getattr(settings, 'FACEBOOK_OFFLINE_ACCESS', False):
+            if request.user.is_authenticated() and not fb_user:
+                profiles = request.user.facebookprofile_set.all()
+                if len(profiles):
+                    for profile in profiles:
+                        if profile.access_token:
+                            fb_user = {
+                                'uid': profile.uid,
+                                'access_token': profile.access_token,
+                                'expires': 0,
+                                'base_domain': request.META['HTTP_HOST'],
+                                'secret': settings.FACEBOOK_SECRET_KEY,
+                                'sig': '',
+                                'session_key': 'offline',
+                            }
+                            break
 
         request.facebook = Facebook(fb_user)
         

--- a/socialregistration/models.py
+++ b/socialregistration/models.py
@@ -8,7 +8,7 @@ class FacebookProfile(models.Model):
     user = models.ForeignKey(User)
     site = models.ForeignKey(Site, default=Site.objects.get_current)
     uid = models.CharField(max_length=255, blank=False, null=False)
-
+    access_token = models.TextField(help_text='only useful if your app has offline_access permission', null=True, blank=True)
     def __unicode__(self):
         if self.pk:
             user = self.user

--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -180,10 +180,12 @@ def twitter(request, account_inactive_template='socialregistration/account_inact
             profile = TwitterProfile.objects.get(twitter_id=user_info['id'])
         except TwitterProfile.DoesNotExist: # There can only be one profile!
             profile = TwitterProfile(user=request.user, twitter_id=user_info['id'])
-            profile.access_token = client._get_at_from_session()['oauth_token']
-            profile.token_secret = client._get_at_from_session()['oauth_token_secret']
-            profile.nick = client._get_at_from_session()['screen_name']
-            profile.save()
+
+        profile.access_token = client._get_at_from_session()['oauth_token']
+        profile.token_secret = client._get_at_from_session()['oauth_token_secret']
+        profile.nick = client._get_at_from_session()['screen_name']
+        print profile, profile.access_token, profile.token_secret, profile.nick
+        profile.save()
 
         return HttpResponseRedirect(_get_next(request))
 
@@ -199,6 +201,13 @@ def twitter(request, account_inactive_template='socialregistration/account_inact
         request.session['socialregistration_user'] = user
         request.session['next'] = _get_next(request)
         return HttpResponseRedirect(reverse('socialregistration_setup'))
+    else:
+        profile = TwitterProfile.objects.get(user=user, twitter_id=user_info['id'])
+        profile.access_token = client._get_at_from_session()['oauth_token']
+        profile.token_secret = client._get_at_from_session()['oauth_token_secret']
+        profile.nick = client._get_at_from_session()['screen_name']
+        profile.save()
+
 
     if not user.is_active:
         return render_to_response(

--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -111,9 +111,13 @@ def facebook_login(request, template='socialregistration/facebook.html',
 
     if user is None:
         request.session['socialregistration_user'] = User()
-        request.session['socialregistration_profile'] = FacebookProfile(uid=request.facebook.uid)
+        request.session['socialregistration_profile'] = FacebookProfile(uid=request.facebook.uid, access_token=request.facebook.access_token)
         request.session['next'] = _get_next(request)
         return HttpResponseRedirect(reverse('socialregistration_setup'))
+    else:
+        profile = FacebookProfile.objects.get(uid=request.facebook.uid)
+        profile.access_token = request.facebook.access_token
+        profile.save()
 
     if not user.is_active:
         return render_to_response(account_inactive_template, extra_context,
@@ -138,6 +142,8 @@ def facebook_connect(request, template='socialregistration/facebook.html',
     except FacebookProfile.DoesNotExist:
         profile = FacebookProfile.objects.create(user=request.user,
             uid=request.facebook.uid)
+    profile.access_token = request.facebook.access_token
+    profile.save()
 
     return HttpResponseRedirect(_get_next(request))
 

--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -179,11 +179,11 @@ def twitter(request, account_inactive_template='socialregistration/account_inact
         try:
             profile = TwitterProfile.objects.get(twitter_id=user_info['id'])
         except TwitterProfile.DoesNotExist: # There can only be one profile!
-            profile = TwitterProfile.objects.create(user=request.user, twitter_id=user_info['id'])
-        profile.access_token = client._get_at_from_session()['oauth_token']
-        profile.token_secret = client._get_at_from_session()['oauth_token_secret']
-        profile.nick = client._get_at_from_session()['screen_name']
-        profile.save()
+            profile = TwitterProfile(user=request.user, twitter_id=user_info['id'])
+            profile.access_token = client._get_at_from_session()['oauth_token']
+            profile.token_secret = client._get_at_from_session()['oauth_token_secret']
+            profile.nick = client._get_at_from_session()['screen_name']
+            profile.save()
 
         return HttpResponseRedirect(_get_next(request))
 
@@ -199,12 +199,6 @@ def twitter(request, account_inactive_template='socialregistration/account_inact
         request.session['socialregistration_user'] = user
         request.session['next'] = _get_next(request)
         return HttpResponseRedirect(reverse('socialregistration_setup'))
-    else:
-        profile = user.twitterprofile_set.get(twitter_id=user_info['id'])
-        profile.access_token = client._get_at_from_session()['oauth_token']
-        profile.token_secret = client._get_at_from_session()['oauth_token_secret']
-        profile.nick = client._get_at_from_session()['screen_name']
-        profile.save()
 
     if not user.is_active:
         return render_to_response(


### PR DESCRIPTION
offline_access facebook permission allows to re-use a facebook authentication token any time.

This also enables socialregistration users to access request.facebook.graph even if the client facebook session expired.

The patch respects backward compatibility, which means that if your app already has offline_access permissions, then it should work out of the box.

The base testing protocol is: sign-in or sign-up to the django site via facebook which should save access_token in the FacebookProfile instance with this patch. Then logout from facebook, clear all cookies, and login to your django site via /admin. If your FacebookProfile has access_token right, then your django site should be able to use request.facebook.graph even though the browser is not logged in facebook.

What do you think ?
