### PR TITLE
Enable custom login buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Supported methods currently are:
 		{% facebook_button %}
 		{% facebook_js %}
 	
+  You can also specify your own custom button image by appending it to the `facebook_button` template tag:
+
+		{% facebook_button 'http://example.com/other_facebook_button.png' %}
+
   You want to keep the `{% facebook_js %}` as far down in your HTML structure as possible to 
   not impact the load time of the page.
   
@@ -98,6 +102,10 @@ Supported methods currently are:
 		{% twitter_button %}
 		
   Same note here. Make sure you're serving the page with a `RequestContext`
+
+  You can also specify your own custom button image by appending it to the `twitter_button` template tag:
+
+		{% twitter_button 'http://example.com/other_twitter_button.png' %}
 
 
 ## OAuth

--- a/socialregistration/templates/socialregistration/facebook_button.html
+++ b/socialregistration/templates/socialregistration/facebook_button.html
@@ -8,5 +8,5 @@
 {% if next %}
     <input type="hidden" name="next" value="{{ next }}" />
 {% endif %}
-<input type="image" onclick="facebookConnect(this.form);return false;" src="http://static.ak.fbcdn.net/images/fbconnect/login-buttons/connect_light_large_long.gif" />
+<input type="image" onclick="facebookConnect(this.form);return false;" src="{% if button %}{{ button }}{% else %}http://static.ak.fbcdn.net/images/fbconnect/login-buttons/connect_light_large_long.gif{% endif %}" />
 </form>

--- a/socialregistration/templates/socialregistration/twitter_button.html
+++ b/socialregistration/templates/socialregistration/twitter_button.html
@@ -4,5 +4,5 @@
 {% if next %}
     <input type="hidden" name="next" value="{{ next }}" />
 {% endif %}
-<input type="image" onclick="this.form.submit();" src="http://apiwiki.twitter.com/f/1242697608/Sign-in-with-Twitter-lighter.png" />
+<input type="image" onclick="this.form.submit();" src="{% if button %}{{ button }}{% else %}http://apiwiki.twitter.com/f/1242697608/Sign-in-with-Twitter-lighter.png{% endif %}" />
 </form>

--- a/socialregistration/templatetags/facebook_tags.py
+++ b/socialregistration/templatetags/facebook_tags.py
@@ -15,7 +15,7 @@ def facebook_js():
     return {'facebook_app_id': id, 'facebook_api_key': key, 'is_https' : bool(_https()), 'facebook_req_perms' : perms }
 
 @register.inclusion_tag('socialregistration/facebook_button.html', takes_context=True)
-def facebook_button(context):
+def facebook_button(context, button=None):
     if not 'request' in context:
         raise AttributeError, 'Please add the ``django.core.context_processors.request`` context processors to your settings.TEMPLATE_CONTEXT_PROCESSORS set'
     logged_in = context['request'].user.is_authenticated()
@@ -23,4 +23,4 @@ def facebook_button(context):
         next = context['next']
     else:
         next = None
-    return dict(next=next, logged_in=logged_in, request=context['request'])
+    return dict(next=next, logged_in=logged_in, button=button, request=context['request'])

--- a/socialregistration/templatetags/twitter_tags.py
+++ b/socialregistration/templatetags/twitter_tags.py
@@ -3,7 +3,7 @@ from django import template
 register = template.Library()
 
 @register.inclusion_tag('socialregistration/twitter_button.html', takes_context=True)
-def twitter_button(context):
+def twitter_button(context, button=None):
     if not 'request' in context:
         raise AttributeError, 'Please add the ``django.core.context_processors.request`` context processors to your settings.TEMPLATE_CONTEXT_PROCESSORS set'
     logged_in = context['request'].user.is_authenticated()
@@ -11,4 +11,4 @@ def twitter_button(context):
         next = context['next']
     else:
         next = None
-    return dict(next=next, logged_in=logged_in, request=context['request'])
+    return dict(next=next, logged_in=logged_in, button=button, request=context['request'])


### PR DESCRIPTION
I changed your templatetags and templates in order to allow direct specification of a custom login button. This is great for people that don't like the default buttons, but don't want to bother with overriding templates.

Example:

```
{% facebook_button 'http://example.com/other_facebook_button.png' %}
```

I also edited the README.md accordingly. Would be cool if you would integrate this into the main branch.
