### PR TITLE
Persist OAuth and Facebook tokens that allow offline access

### DIFF
--- a/socialregistration/migrations/0002_offline_access.py
+++ b/socialregistration/migrations/0002_offline_access.py
@@ -1,0 +1,155 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding model 'TwitterAccessToken'
+        db.create_table('socialregistration_twitteraccesstoken', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('request_token', self.gf('django.db.models.fields.related.OneToOneField')(related_name='access_token', unique=True, to=orm['socialregistration.TwitterRequestToken'])),
+            ('oauth_token', self.gf('django.db.models.fields.CharField')(max_length=80)),
+            ('oauth_token_secret', self.gf('django.db.models.fields.CharField')(max_length=80)),
+        ))
+        db.send_create_signal('socialregistration', ['TwitterAccessToken'])
+
+        # Adding model 'FacebookAccessToken'
+        db.create_table('socialregistration_facebookaccesstoken', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('facebook_profile', self.gf('django.db.models.fields.related.OneToOneField')(related_name='offline_access', unique=True, to=orm['socialregistration.FacebookProfile'])),
+            ('access_token', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal('socialregistration', ['FacebookAccessToken'])
+
+        # Adding model 'TwitterRequestToken'
+        db.create_table('socialregistration_twitterrequesttoken', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('twitter_profile', self.gf('django.db.models.fields.related.OneToOneField')(related_name='request_token', unique=True, to=orm['socialregistration.TwitterProfile'])),
+            ('oauth_token', self.gf('django.db.models.fields.CharField')(max_length=80)),
+            ('oauth_token_secret', self.gf('django.db.models.fields.CharField')(max_length=80)),
+        ))
+        db.send_create_signal('socialregistration', ['TwitterRequestToken'])
+
+
+    def backwards(self, orm):
+        
+        # Deleting model 'TwitterAccessToken'
+        db.delete_table('socialregistration_twitteraccesstoken')
+
+        # Deleting model 'FacebookAccessToken'
+        db.delete_table('socialregistration_facebookaccesstoken')
+
+        # Deleting model 'TwitterRequestToken'
+        db.delete_table('socialregistration_twitterrequesttoken')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'sites.site': {
+            'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'socialregistration.facebookaccesstoken': {
+            'Meta': {'object_name': 'FacebookAccessToken'},
+            'access_token': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'facebook_profile': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'offline_access'", 'unique': 'True', 'to': "orm['socialregistration.FacebookProfile']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'socialregistration.facebookprofile': {
+            'Meta': {'object_name': 'FacebookProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
+            'uid': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'socialregistration.openidnonce': {
+            'Meta': {'object_name': 'OpenIDNonce'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'salt': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'timestamp': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'socialregistration.openidprofile': {
+            'Meta': {'object_name': 'OpenIDProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'identity': ('django.db.models.fields.TextField', [], {}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'socialregistration.openidstore': {
+            'Meta': {'object_name': 'OpenIDStore'},
+            'assoc_type': ('django.db.models.fields.TextField', [], {}),
+            'handle': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issued': ('django.db.models.fields.IntegerField', [], {}),
+            'lifetime': ('django.db.models.fields.IntegerField', [], {}),
+            'secret': ('django.db.models.fields.TextField', [], {}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"})
+        },
+        'socialregistration.twitteraccesstoken': {
+            'Meta': {'object_name': 'TwitterAccessToken'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'oauth_token': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'oauth_token_secret': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'request_token': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'access_token'", 'unique': 'True', 'to': "orm['socialregistration.TwitterRequestToken']"})
+        },
+        'socialregistration.twitterprofile': {
+            'Meta': {'object_name': 'TwitterProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
+            'twitter_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'socialregistration.twitterrequesttoken': {
+            'Meta': {'object_name': 'TwitterRequestToken'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'oauth_token': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'oauth_token_secret': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'twitter_profile': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'request_token'", 'unique': 'True', 'to': "orm['socialregistration.TwitterProfile']"})
+        }
+    }
+
+    complete_apps = ['socialregistration']

--- a/socialregistration/models.py
+++ b/socialregistration/models.py
@@ -18,6 +18,10 @@ class FacebookProfile(models.Model):
     def authenticate(self):
         return authenticate(uid=self.uid)
 
+class FacebookAccessToken(models.Model):
+    facebook_profile = models.OneToOneField(FacebookProfile,related_name='offline_access')
+    access_token = models.CharField(max_length=255)
+
 class TwitterProfile(models.Model):
     user = models.ForeignKey(User)
     site = models.ForeignKey(Site, default=Site.objects.get_current)
@@ -31,6 +35,16 @@ class TwitterProfile(models.Model):
 
     def authenticate(self):
         return authenticate(twitter_id=self.twitter_id)
+
+class TwitterRequestToken(models.Model):
+    twitter_profile = models.OneToOneField(TwitterProfile,related_name='request_token')
+    oauth_token = models.CharField(max_length=80)
+    oauth_token_secret = models.CharField(max_length=80)
+
+class TwitterAccessToken(models.Model):
+    request_token = models.OneToOneField(TwitterRequestToken,related_name='access_token')
+    oauth_token = models.CharField(max_length=80)
+    oauth_token_secret = models.CharField(max_length=80)
 
 class OpenIDProfile(models.Model):
     user = models.ForeignKey(User)


### PR DESCRIPTION
This patch will save OAuth request/access tokens and Facebook offline_access token into the database. These can be used to access the accounts offline.
