### PR TITLE
Updated src URL for Twitter login button to reflect new URL from Twitter 

### DIFF
--- a/socialregistration/templates/socialregistration/twitter_button.html
+++ b/socialregistration/templates/socialregistration/twitter_button.html
@@ -4,5 +4,5 @@
 {% if next %}
     <input type="hidden" name="next" value="{{ next }}" />
 {% endif %}
-<input type="image" onclick="this.form.submit();" src="{% if button %}{{ button }}{% else %}http://apiwiki.twitter.com/f/1242697608/Sign-in-with-Twitter-lighter.png{% endif %}" />
+<input type="image" onclick="this.form.submit();" src="{% if button %}{{ button }}{% else %}https://si0.twimg.com/images/dev/buttons/sign-in-with-twitter-l.png{% endif %}" />
 </form>


### PR DESCRIPTION
Updated src URL for Twitter login button to reflect new URL from Twitter (as provided at https://dev.twitter.com/docs/auth/sign-in-with-twitter). Old URL was throwing 404 errors.
