### PR TITLE
Fixing an issue where 'next' is lost in a new user signup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Clay McClure <clay@daemons.net>
 Danilo Bargen <gezuru@gmail.com>
 Horst Gutmann <zerok@zerokspot.com>
 Ian Langworth <ian@langworth.com>
+James Addison <code@scottisheyes.com>
 Joeri Djojosoeparto <jsoejitno@gmail.com>
 Joseph Bergantine <jbergantine@gmail.com>
 Tobias Hasselrot <tobias.hasselrot@gmail.com>

--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -44,7 +44,12 @@ def _get_next(request):
         return getattr(settings, 'LOGIN_REDIRECT_URL', '/')
 
 def _login(request, user, profile, client):
+    # we need to persist 'next' across the call to login() as
+    # it appears to reset the session data.
+    next = client.request.session.get('next')
     login(request, user)
+    if next:
+        request.session['next'] = next
     signals.login.send(sender = profile.__class__, 
                                   user = user,
                                   profile = profile, 

--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -46,7 +46,7 @@ def _get_next(request):
 def _login(request, user, profile, client):
     # we need to persist 'next' across the call to login() as
     # it appears to reset the session data.
-    next = client.request.session.get('next')
+    next = request.session.get('next')
     login(request, user)
     if next:
         request.session['next'] = next


### PR DESCRIPTION
Issue was found when creating a new user via Facebook Connect, the 'next' session variable gets lost when login() is called - Django is designed to do this.  This fix simply retrieves the value of 'next' before the call to login() and sets it back afterward.
