### PR TITLE
Template Tags Conflict With Django Pagination

### DIFF
--- a/socialregistration/templatetags/facebook_tags.py
+++ b/socialregistration/templatetags/facebook_tags.py
@@ -19,8 +19,8 @@ def facebook_button(context, button=None):
     if not 'request' in context:
         raise AttributeError, 'Please add the ``django.core.context_processors.request`` context processors to your settings.TEMPLATE_CONTEXT_PROCESSORS set'
     logged_in = context['request'].user.is_authenticated()
-    if 'next' in context:
-        next = context['next']
+    if 'next_page' in context:
+        next_page = context['next_page']
     else:
-        next = None
-    return dict(next=next, logged_in=logged_in, button=button, request=context['request'])
+        next_page = None
+    return dict(next=next_page, logged_in=logged_in, button=button, request=context['request'])

--- a/socialregistration/templatetags/openid_tags.py
+++ b/socialregistration/templatetags/openid_tags.py
@@ -7,8 +7,8 @@ def openid_form(context):
     if not 'request' in context:
         raise AttributeError, 'Please add the ``django.core.context_processors.request`` context processors to your settings.TEMPLATE_CONTEXT_PROCESSORS set'
     logged_in = context['request'].user.is_authenticated()
-    if 'next' in context:
-        next = context['next']
+    if 'next_page' in context:
+        next_page = context['next_page']
     else:
-        next = None
-    return dict(next=next, logged_in=logged_in, request=context['request'])
+        next_page = None
+    return dict(next=next_page, logged_in=logged_in, request=context['request'])

--- a/socialregistration/templatetags/twitter_tags.py
+++ b/socialregistration/templatetags/twitter_tags.py
@@ -7,8 +7,8 @@ def twitter_button(context, button=None):
     if not 'request' in context:
         raise AttributeError, 'Please add the ``django.core.context_processors.request`` context processors to your settings.TEMPLATE_CONTEXT_PROCESSORS set'
     logged_in = context['request'].user.is_authenticated()
-    if 'next' in context:
-        next = context['next']
+    if 'next_page' in context:
+        next_page = context['next_page']
     else:
-        next = None
-    return dict(next=next, logged_in=logged_in, button=button, request=context['request'])
+        next_page = None
+    return dict(next=next_page, logged_in=logged_in, button=button, request=context['request'])


### PR DESCRIPTION
The template context variable 'next' conflicts with django pagination in generic views.
I've renamed it to next_page to avoid conflict.

I noticed that on pages where I was using a generic view with the paginate_by value set and also including the login buttons, clicking them would lead to pages like this.
http://127.0.0.1:8000/social/facebook/login/2

The buttons have a hidden form field with the context variable next. As it turns out, Django pagination also sets that variable with the number of the next page.

To reproduce this error, do something like this and put the facebook and twitter tags in the template.

```
from django.views.generic import list_detail
urlpatterns = patterns('',
    (r'^mymodel/(page/(?P<page>[0-9]+)/)?$', list_detail.object_list, { "queryset": MyModel.objects.all(), "paginate_by":20}),
)
```
