### PR TITLE
Support for LinkedIn via OAuth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Ian Langworth <ian@langworth.com>
 James Addison <code@scottisheyes.com>
 Joeri Djojosoeparto <jsoejitno@gmail.com>
 Joseph Bergantine <jbergantine@gmail.com>
+Thejaswi Puthraya <thejaswi.puthraya@gmail.com>
 Tobias Hasselrot <tobias.hasselrot@gmail.com>
 Tom Drummond <tom@devioustree.co.uk>
 Zellyn Hunter <Zellyn.Hunter@cmgdigital.com>

--- a/README.md
+++ b/README.md
@@ -108,6 +108,35 @@ Supported methods currently are:
 		{% twitter_button 'http://example.com/other_twitter_button.png' %}
 
 
+## LinkedIn
+
+#### Configuration  
+
+1. Add the LinkedIn API keys and endpoints to your settings, variable names are
+
+       	    LINKEDIN_CONSUMER_KEY = ''
+	    LINKEDIN_CONSUMER_SECRET_KEY = ''
+	    LINKEDIN_REQUEST_TOKEN_URL = ''
+	    LINKEDIN_ACCESS_TOKEN_URL = ''
+	    LINKEDIN_AUTHORIZATION_URL = ''
+		
+2. Add `socialregistration.auth.LinkedInAuth` to `AUTHENTICATION_BACKENDS`
+3. Add the right callback URL to your LinkedIn account
+
+#### Usage
+
+* Add tags to your template file
+
+		{% load linkedin_tags %}
+		{% linkedin_button %}
+		
+  Same note here. Make sure you're serving the page with a `RequestContext`
+
+  You can also specify your own custom button image by appending it to the `linkedin_button` template tag:
+
+		{% linkedin_button 'http://example.com/other_linkedin_button.png' %}
+
+
 ## OAuth
 
 Check out how the Twitter authentication works. Basically it's just plugging

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,47 @@ You can also specify your own custom button image by appending it to the
 
         {% twitter_button 'http://example.com/other_twitter_button.png' %}
 
+LinkedIn
+--------
+
+Configuration
+^^^^^^^^^^^^^
+
+1. Add the LinkedIn API keys and endpoints to your settings, variable
+   names are
+
+   ::
+
+       LINKEDIN_CONSUMER_KEY = ''
+       LINKEDIN_CONSUMER_SECRET_KEY = ''
+       LINKEDIN_REQUEST_TOKEN_URL = ''
+       LINKEDIN_ACCESS_TOKEN_URL = ''
+       LINKEDIN_AUTHORIZATION_URL = ''
+
+2. Add ``socialregistration.auth.LinkedInAuth`` to
+   ``AUTHENTICATION_BACKENDS``
+3. Add the right callback URL to your LinkedIn account
+
+Usage
+^^^^^
+
+-  Add tags to your template file
+
+   ::
+
+       {% load linkedin_tags %}
+       {% linkedin_button %}
+
+Same note here. Make sure you're serving the page with a
+``RequestContext``
+
+You can also specify your own custom button image by appending it to the
+``linkedin_button`` template tag:
+
+::
+
+        {% linkedin_button 'http://example.com/other_linkedin_button.png' %}
+
 OAuth
 -----
 

--- a/socialregistration/admin.py
+++ b/socialregistration/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 from socialregistration.models import (FacebookProfile, TwitterProfile,
-    OpenIDProfile, OpenIDStore, OpenIDNonce)
+    OpenIDProfile, OpenIDStore, OpenIDNonce, LinkedInProfile)
 
-admin.site.register([FacebookProfile, TwitterProfile, OpenIDProfile, OpenIDStore, OpenIDNonce])
+admin.site.register([FacebookProfile, TwitterProfile, LinkedInProfile, 
+                     OpenIDProfile, OpenIDStore, OpenIDNonce])
 
 

--- a/socialregistration/auth.py
+++ b/socialregistration/auth.py
@@ -1,7 +1,8 @@
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 
-from socialregistration.models import (FacebookProfile, TwitterProfile, OpenIDProfile)
+from socialregistration.models import (FacebookProfile, TwitterProfile, 
+                                       OpenIDProfile, LinkedInProfile)
 
 class Auth(object):
     supports_object_permissions = False
@@ -30,6 +31,16 @@ class TwitterAuth(Auth):
                 site=Site.objects.get_current()
             ).user
         except TwitterProfile.DoesNotExist:
+            return None
+
+class LinkedInAuth(Auth):
+    def authenticate(self, linkedin_id=None):
+        try:
+            return LinkedInProfile.objects.get(
+                linkedin_id=linkedin_id,
+                site=Site.objects.get_current()
+            ).user
+        except LinkedInProfile.DoesNotExist:
             return None
 
 class OpenIDAuth(Auth):

--- a/socialregistration/migrations/0003_auto__add_unique_twitterprofile_user__add_unique_openidprofile_user__a.py
+++ b/socialregistration/migrations/0003_auto__add_unique_twitterprofile_user__add_unique_openidprofile_user__a.py
@@ -1,0 +1,138 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding unique constraint on 'TwitterProfile', fields ['user']
+        db.create_unique('socialregistration_twitterprofile', ['user_id'])
+
+        # Adding unique constraint on 'OpenIDProfile', fields ['user']
+        db.create_unique('socialregistration_openidprofile', ['user_id'])
+
+        # Adding unique constraint on 'FacebookProfile', fields ['user']
+        db.create_unique('socialregistration_facebookprofile', ['user_id'])
+
+
+    def backwards(self, orm):
+        
+        # Removing unique constraint on 'FacebookProfile', fields ['user']
+        db.delete_unique('socialregistration_facebookprofile', ['user_id'])
+
+        # Removing unique constraint on 'OpenIDProfile', fields ['user']
+        db.delete_unique('socialregistration_openidprofile', ['user_id'])
+
+        # Removing unique constraint on 'TwitterProfile', fields ['user']
+        db.delete_unique('socialregistration_twitterprofile', ['user_id'])
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'sites.site': {
+            'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'socialregistration.facebookaccesstoken': {
+            'Meta': {'object_name': 'FacebookAccessToken'},
+            'access_token': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'profile': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'access_token'", 'unique': 'True', 'to': "orm['socialregistration.FacebookProfile']"})
+        },
+        'socialregistration.facebookprofile': {
+            'Meta': {'object_name': 'FacebookProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
+            'uid': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'socialregistration.openidnonce': {
+            'Meta': {'object_name': 'OpenIDNonce'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'salt': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'timestamp': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'socialregistration.openidprofile': {
+            'Meta': {'object_name': 'OpenIDProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'identity': ('django.db.models.fields.TextField', [], {}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'socialregistration.openidstore': {
+            'Meta': {'object_name': 'OpenIDStore'},
+            'assoc_type': ('django.db.models.fields.TextField', [], {}),
+            'handle': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issued': ('django.db.models.fields.IntegerField', [], {}),
+            'lifetime': ('django.db.models.fields.IntegerField', [], {}),
+            'secret': ('django.db.models.fields.TextField', [], {}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"})
+        },
+        'socialregistration.twitteraccesstoken': {
+            'Meta': {'object_name': 'TwitterAccessToken'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'oauth_token': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'oauth_token_secret': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'profile': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'access_token'", 'unique': 'True', 'to': "orm['socialregistration.TwitterProfile']"})
+        },
+        'socialregistration.twitterprofile': {
+            'Meta': {'object_name': 'TwitterProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
+            'twitter_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'socialregistration.twitterrequesttoken': {
+            'Meta': {'object_name': 'TwitterRequestToken'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'oauth_token': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'oauth_token_secret': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'profile': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'request_token'", 'unique': 'True', 'to': "orm['socialregistration.TwitterProfile']"})
+        }
+    }
+
+    complete_apps = ['socialregistration']

--- a/socialregistration/migrations/0004_auto__add_linkedinprofile__add_linkedinrequesttoken__add_linkedinacces.py
+++ b/socialregistration/migrations/0004_auto__add_linkedinprofile__add_linkedinrequesttoken__add_linkedinacces.py
@@ -1,0 +1,177 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding model 'LinkedInProfile'
+        db.create_table('socialregistration_linkedinprofile', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'], unique=True)),
+            ('site', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['sites.Site'])),
+            ('linkedin_id', self.gf('django.db.models.fields.CharField')(max_length=25)),
+        ))
+        db.send_create_signal('socialregistration', ['LinkedInProfile'])
+
+        # Adding model 'LinkedInRequestToken'
+        db.create_table('socialregistration_linkedinrequesttoken', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('profile', self.gf('django.db.models.fields.related.OneToOneField')(related_name='request_token', unique=True, to=orm['socialregistration.LinkedInProfile'])),
+            ('oauth_token', self.gf('django.db.models.fields.CharField')(max_length=80)),
+            ('oauth_token_secret', self.gf('django.db.models.fields.CharField')(max_length=80)),
+        ))
+        db.send_create_signal('socialregistration', ['LinkedInRequestToken'])
+
+        # Adding model 'LinkedInAccessToken'
+        db.create_table('socialregistration_linkedinaccesstoken', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('profile', self.gf('django.db.models.fields.related.OneToOneField')(related_name='access_token', unique=True, to=orm['socialregistration.LinkedInProfile'])),
+            ('oauth_token', self.gf('django.db.models.fields.CharField')(max_length=80)),
+            ('oauth_token_secret', self.gf('django.db.models.fields.CharField')(max_length=80)),
+        ))
+        db.send_create_signal('socialregistration', ['LinkedInAccessToken'])
+
+
+    def backwards(self, orm):
+        
+        # Deleting model 'LinkedInProfile'
+        db.delete_table('socialregistration_linkedinprofile')
+
+        # Deleting model 'LinkedInRequestToken'
+        db.delete_table('socialregistration_linkedinrequesttoken')
+
+        # Deleting model 'LinkedInAccessToken'
+        db.delete_table('socialregistration_linkedinaccesstoken')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'sites.site': {
+            'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'socialregistration.facebookaccesstoken': {
+            'Meta': {'object_name': 'FacebookAccessToken'},
+            'access_token': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'profile': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'access_token'", 'unique': 'True', 'to': "orm['socialregistration.FacebookProfile']"})
+        },
+        'socialregistration.facebookprofile': {
+            'Meta': {'object_name': 'FacebookProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
+            'uid': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'socialregistration.linkedinaccesstoken': {
+            'Meta': {'object_name': 'LinkedInAccessToken'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'oauth_token': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'oauth_token_secret': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'profile': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'access_token'", 'unique': 'True', 'to': "orm['socialregistration.LinkedInProfile']"})
+        },
+        'socialregistration.linkedinprofile': {
+            'Meta': {'object_name': 'LinkedInProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'linkedin_id': ('django.db.models.fields.CharField', [], {'max_length': '25'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'socialregistration.linkedinrequesttoken': {
+            'Meta': {'object_name': 'LinkedInRequestToken'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'oauth_token': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'oauth_token_secret': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'profile': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'request_token'", 'unique': 'True', 'to': "orm['socialregistration.LinkedInProfile']"})
+        },
+        'socialregistration.openidnonce': {
+            'Meta': {'object_name': 'OpenIDNonce'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'salt': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'timestamp': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'socialregistration.openidprofile': {
+            'Meta': {'object_name': 'OpenIDProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'identity': ('django.db.models.fields.TextField', [], {}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'socialregistration.openidstore': {
+            'Meta': {'object_name': 'OpenIDStore'},
+            'assoc_type': ('django.db.models.fields.TextField', [], {}),
+            'handle': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issued': ('django.db.models.fields.IntegerField', [], {}),
+            'lifetime': ('django.db.models.fields.IntegerField', [], {}),
+            'secret': ('django.db.models.fields.TextField', [], {}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"})
+        },
+        'socialregistration.twitteraccesstoken': {
+            'Meta': {'object_name': 'TwitterAccessToken'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'oauth_token': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'oauth_token_secret': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'profile': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'access_token'", 'unique': 'True', 'to': "orm['socialregistration.TwitterProfile']"})
+        },
+        'socialregistration.twitterprofile': {
+            'Meta': {'object_name': 'TwitterProfile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['sites.Site']"}),
+            'twitter_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'socialregistration.twitterrequesttoken': {
+            'Meta': {'object_name': 'TwitterRequestToken'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'oauth_token': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'oauth_token_secret': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'profile': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'request_token'", 'unique': 'True', 'to': "orm['socialregistration.TwitterProfile']"})
+        }
+    }
+
+    complete_apps = ['socialregistration']

--- a/socialregistration/templates/socialregistration/linkedin_button.html
+++ b/socialregistration/templates/socialregistration/linkedin_button.html
@@ -1,0 +1,8 @@
+{% load linkedin_tags socialregistration_tags %}
+<form class="connect-button" name="login" method="post" action="{% url linkedin_redirect %}">
+{% social_csrf_token %}
+{% if next %}
+    <input type="hidden" name="next" value="{{ next }}" />
+{% endif %}
+<input type="image" onclick="this.form.submit();" src="{% if button %}{{ button }}{% else %}http://developer.linkedin.com/sites/default/files/linkedin-small.png{% endif %}" />
+</form>

--- a/socialregistration/templatetags/linkedin_tags.py
+++ b/socialregistration/templatetags/linkedin_tags.py
@@ -1,0 +1,14 @@
+from django import template
+
+register = template.Library()
+
+@register.inclusion_tag('socialregistration/linkedin_button.html', takes_context=True)
+def linkedin_button(context, button=None):
+    if not 'request' in context:
+        raise AttributeError, 'Please add the ``django.core.context_processors.request`` context processors to your settings.TEMPLATE_CONTEXT_PROCESSORS set'
+    logged_in = context['request'].user.is_authenticated()
+    if 'next' in context:
+        next = context['next']
+    else:
+        next = None
+    return dict(next=next, logged_in=logged_in, button=button, request=context['request'])

--- a/socialregistration/urls.py
+++ b/socialregistration/urls.py
@@ -7,7 +7,7 @@ Updated on 19.12.2009
 from django.conf import settings
 from django.conf.urls.defaults import *
 
-from socialregistration.utils import OpenID, OAuthClient, OAuthTwitter
+from socialregistration.utils import OpenID, OAuthClient, OAuthTwitter, OAuthLinkedIn
 
 
 urlpatterns = patterns('',
@@ -60,6 +60,36 @@ if getattr(settings, 'TWITTER_CONSUMER_KEY', None) is not None:
             name='twitter_callback'
         ),
         url('^twitter/$', 'socialregistration.views.twitter', {'client_class': OAuthTwitter}, name='twitter'),
+    )
+
+#Setup LinkedIn URLs if there's an API key specified
+if getattr(settings, 'LINKEDIN_CONSUMER_KEY', None) is not None:
+    urlpatterns = urlpatterns + patterns('',
+        url('^linkedin/redirect/$', 'socialregistration.views.oauth_redirect',
+            dict(
+                consumer_key=settings.LINKEDIN_CONSUMER_KEY,
+                secret_key=settings.LINKEDIN_CONSUMER_SECRET_KEY,
+                request_token_url=settings.LINKEDIN_REQUEST_TOKEN_URL,
+                access_token_url=settings.LINKEDIN_ACCESS_TOKEN_URL,
+                authorization_url=settings.LINKEDIN_AUTHORIZATION_URL,
+                callback_url='linkedin_callback',
+                client_class = OAuthClient
+            ),
+            name='linkedin_redirect'),
+
+        url('^linkedin/callback/$', 'socialregistration.views.oauth_callback',
+            dict(
+                consumer_key=settings.LINKEDIN_CONSUMER_KEY,
+                secret_key=settings.LINKEDIN_CONSUMER_SECRET_KEY,
+                request_token_url=settings.LINKEDIN_REQUEST_TOKEN_URL,
+                access_token_url=settings.LINKEDIN_ACCESS_TOKEN_URL,
+                authorization_url=settings.LINKEDIN_AUTHORIZATION_URL,
+                callback_url='linkedin',
+                client_class = OAuthClient
+            ),
+            name='linkedin_callback'
+        ),
+        url('^linkedin/$', 'socialregistration.views.linkedin', {'client_class': OAuthLinkedIn}, name='linkedin'),
     )
 
 urlpatterns = urlpatterns + patterns('',

--- a/socialregistration/utils.py
+++ b/socialregistration/utils.py
@@ -343,3 +343,9 @@ class OAuthTwitter(OAuth):
     def get_user_info(self):
         user = simplejson.loads(self.query(self.url))
         return user
+
+class OAuthLinkedIn(OAuthTwitter):
+    """
+    Verifying linkedin credentials
+    """
+    url = "http://api.linkedin.com/v1/people/~:(id)?format=json"


### PR DESCRIPTION
There is support for OAuth and LinkedIn can be added very easily but I didn't want to repeat myself constantly and hence wish to have this part of django-socialregistration.

The settings attribute required for this are:
LINKEDIN_CONSUMER_KEY = ''
LINKEDIN_CONSUMER_SECRET_KEY = ''
LINKEDIN_REQUEST_TOKEN_URL = 'https://api.linkedin.com/uas/oauth/requestToken'
LINKEDIN_ACCESS_TOKEN_URL = 'https://api.linkedin.com/uas/oauth/accessToken'
LINKEDIN_AUTHORIZATION_URL = 'https://api.linkedin.com/uas/oauth/authenticate'
