### PR TITLE
Adding the request to the social_client (Facebook) obj

### DIFF
--- a/socialregistration/middleware.py
+++ b/socialregistration/middleware.py
@@ -10,18 +10,21 @@ class Facebook(object):
             self.uid = user['uid']
             self.user = user
 
+        self.access_token = None
+
     def get_graph(self):
-        return facebook.GraphAPI(
-            facebook.get_user_access_token(
-                self.user['code'],
+        if not self.access_token:
+            self.access_token = facebook.get_user_access_token(
+                self.user.get('code', ''),
                 getattr(
                     settings,
                     'FACEBOOK_APP_ID',
                     settings.FACEBOOK_API_KEY
-                    ),
-                settings.FACEBOOK_SECRET_KEY,
-                ).get('access_token', None)
-            )
+                ),
+                settings.FACEBOOK_SECRET_KEY
+            ).get('access_token', None)
+
+        return facebook.GraphAPI(self.access_token)
 
 
 class FacebookMiddleware(object):

--- a/socialregistration/middleware.py
+++ b/socialregistration/middleware.py
@@ -9,7 +9,6 @@ class Facebook(object):
         else:
             self.uid = user['uid']
             self.user = user
-            self.graph = facebook.GraphAPI(user['access_token'])
 
 
 class FacebookMiddleware(object):

--- a/socialregistration/middleware.py
+++ b/socialregistration/middleware.py
@@ -1,6 +1,7 @@
 import facebook
 from django.conf import settings
 
+
 class Facebook(object):
     def __init__(self, user=None):
         if user is None:

--- a/socialregistration/middleware.py
+++ b/socialregistration/middleware.py
@@ -36,12 +36,13 @@ class FacebookMiddleware(object):
                     ),
                 settings.FACEBOOK_SECRET_KEY,
                 )
-            if not data:
-                return None
-            fb_user = {
-                'access_token': data['code'],
-                'uid': data['user_id'],
-                }
+            if data:
+                fb_user = {
+                    'code': data['code'],
+                    'uid': data['user_id'],
+                    }
+            else:
+                fb_user = None
 
         request.facebook = Facebook(fb_user)
         

--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -167,6 +167,7 @@ def facebook_connect(request, template='socialregistration/facebook.html',
     except FacebookProfile.DoesNotExist:
         profile = FacebookProfile.objects.create(user=request.user,
             uid=request.facebook.uid)
+        request.facebook.request = request
         _connect(request.user, profile, request.facebook)
 
     return HttpResponseRedirect(_get_next(request))


### PR DESCRIPTION
Adding 'request' to the social_client on connecting a Facebook profile to an existing user - matches the setup() view.  This allows signals to set user messages.

This happens in all other signup/signin cases with twitter and facebook, except in the case where hooking up FB to an existing user, it seems.
