### PR TITLE
Support client-side OAuth 2 with Facebook

### DIFF
--- a/socialregistration/middleware.py
+++ b/socialregistration/middleware.py
@@ -23,6 +23,26 @@ class FacebookMiddleware(object):
         fb_user = facebook.get_user_from_cookie(request.COOKIES,
             getattr(settings, 'FACEBOOK_APP_ID', settings.FACEBOOK_API_KEY), settings.FACEBOOK_SECRET_KEY)
 
+        if fb_user is None:
+            # maybe OAuth 2
+            data = facebook.parse_signed_request(
+                request.COOKIES.get(
+                    'fbsr_' + getattr(
+                        settings,
+                        'FACEBOOK_APP_ID',
+                        settings.FACEBOOK_API_KEY
+                        ),
+                    '',
+                    ),
+                settings.FACEBOOK_SECRET_KEY,
+                )
+            if not data:
+                return None
+            fb_user = {
+                'access_token': data['code'],
+                'uid': data['user_id'],
+                }
+
         request.facebook = Facebook(fb_user)
         
         return None


### PR DESCRIPTION
It's probably an idea to implement server-side OAuth 2, which should be largely like twitter / linkedin (and should be testable more readily). However since everything is running client-side with socialregistration & Facebook at the moment, this should be a helpful first step.

Note that this is pretty critical: OAuth 1 is being turned off on 1st October — see https://developers.facebook.com/blog/post/525/.

Note that this relies on using the fork of the facebook python SDK at
https://github.com/pythonforfacebook/facebook-sdk rather than the
"official" one which doesn't support OAuth 2, still uses urllib, and
has a number of other defects.
