### PR TITLE
Further work on jaddison's patch

### DIFF
--- a/socialregistration/middleware.py
+++ b/socialregistration/middleware.py
@@ -9,7 +9,6 @@ class Facebook(object):
         else:
             self.uid = user['uid']
             self.user = user
-            self.graph = facebook.GraphAPI(user['access_token'])
 
 
 class FacebookMiddleware(object):

--- a/socialregistration/middleware.py
+++ b/socialregistration/middleware.py
@@ -1,6 +1,7 @@
 import facebook
 from django.conf import settings
 
+
 class Facebook(object):
     def __init__(self, user=None):
         if user is None:

--- a/socialregistration/middleware.py
+++ b/socialregistration/middleware.py
@@ -36,12 +36,13 @@ class FacebookMiddleware(object):
                     ),
                 settings.FACEBOOK_SECRET_KEY,
                 )
-            if not data:
-                return None
-            fb_user = {
-                'access_token': data['code'],
-                'uid': data['user_id'],
-                }
+            if data:
+                fb_user = {
+                    'code': data['code'],
+                    'uid': data['user_id'],
+                    }
+            else:
+                fb_user = None
 
         request.facebook = Facebook(fb_user)
         

--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -167,6 +167,7 @@ def facebook_connect(request, template='socialregistration/facebook.html',
     except FacebookProfile.DoesNotExist:
         profile = FacebookProfile.objects.create(user=request.user,
             uid=request.facebook.uid)
+        request.facebook.request = request
         _connect(request.user, profile, request.facebook)
 
     return HttpResponseRedirect(_get_next(request))


### PR DESCRIPTION
This introduces a way of getting the GraphAPI object fairly painlessly from the Facebook object (relies on James' fork of the pythonforfacebook facebook-sdk).

It also stops putting a pointless Facebook object on request.facebook; if there's no extractable Facebook cookie, don't put anything there. (An alternative would be to set it to `None`.)
