### PR TITLE
Interoperate with conformat OpenID providers that send assertions as a POST

### DIFF
--- a/socialregistration/utils.py
+++ b/socialregistration/utils.py
@@ -142,9 +142,11 @@ class OpenID(object):
 
     def complete(self):
         self.result = self.consumer.complete(
-            dict(self.request.GET.items()),
+            # When a message is sent as a POST, OpenID parameters MUST only be
+            # sent in, and extracted from, the POST body.
+            dict(self.request.POST.items() if 'POST' == self.request.method else self.request.GET.items()),
             'http%s://%s%s' % (_https(), Site.objects.get_current(),
-                self.request.path)
+                self.request.get_full_path())
         )
 
     def is_valid(self):


### PR DESCRIPTION
OpenID specification allows providers to send indirect messages as either a GET or a POST - this application previously only supported assertions sent as a GET, and failed to interoperate with providers that send assertions as a POST
