### PR TITLE
Creation of inactive users

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Thejaswi Puthraya <thejaswi.puthraya@gmail.com>
 Tobias Hasselrot <tobias.hasselrot@gmail.com>
 Tom Drummond <tom@devioustree.co.uk>
 Zellyn Hunter <Zellyn.Hunter@cmgdigital.com>
+Liz Rice <liz@lizrice.com>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,6 +48,23 @@ Include ``socialregistration.urls`` into your root ``urls.py`` file
 
 	The ``namespace = 'socialregistration'`` argument is required.
 
+Include ``django.core.context_processors.request`` in your TEMPLATE_CONTEXT_PROCESSORS in your settings file
+
+::
+
+	TEMPLATE_CONTEXT_PROESSORS = (
+        'django.core.context_processors.request',
+	)
+
+.. note::
+
+	When your views render templates that include social registration tags (such as {% twitter_button %}) 
+	they will need to pass the RequestContext in as a parameter
+
+::
+
+	return render_to_response('template.html', c, context_instance=RequestContext(request))
+
 Note on sessions
 ================
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,7 +34,10 @@ The most basic configuration is to add ``socialregistration`` and
 
     To make sure that your redirects and callbacks work properly you'll have to set
     the domain in the `Sites app <https://docs.djangoproject.com/en/1.3/ref/contrib/sites/>`_
-    to the correct value.
+    to the correct value. 
+    
+    If you find yourself redirected to example.com, check your Sites configuration through the 
+    Django admin interface.
 
 Include ``socialregistration.urls`` into your root ``urls.py`` file
 

--- a/socialregistration/mixins.py
+++ b/socialregistration/mixins.py
@@ -57,8 +57,11 @@ class CommonMixin(TemplateResponseMixin):
         """
         Return an inactive message.
         """
-        return self.render_to_response({
-            'error': _("This user account is marked as inactive.")})
+        inactive_url = getattr(settings, 'LOGIN_INACTIVE_REDIRECT_URL', '')
+        if inactive_url:
+            return HttpResponseRedirect(inactive_url)
+        else:
+            return self.render_to_response({'error': _("This user account is marked as inactive.")})
 
     def redirect(self, request):
         """

--- a/socialregistration/tests.py
+++ b/socialregistration/tests.py
@@ -82,9 +82,10 @@ class OAuthTest(object):
     def create_profile(self):
         raise NotImplementedError
     
-    def create_user(self):
+    def create_user(self, is_active=True):
         user = User.objects.create(username='alen')
         user.set_password('test')
+        user.is_active = is_active
         user.save()
         return user
     
@@ -196,6 +197,16 @@ class OAuthTest(object):
         
         self.assertEqual(1, counter.counter)
 
+    def test_setup_callback_should_indicate_a_logged_in_inactive_user(self):
+        user = self.create_user(is_active=False)
+        self.create_profile(user)
+
+        self.redirect()
+        self.callback()
+        response = self.setup_callback()
+
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertContains(response, "inactive", 1)
 
 class OAuth2Test(OAuthTest):
 


### PR DESCRIPTION
Hello, 

This is a little change to allow social-registration to redirect to LOGIN_REDIRECT_INACTIVE_URL (rather than throwing an error) when a user is created or signed in through social-registration, but is inactive.  Useful if you're limiting the number of users, for example in a limited beta trial.  

Also a couple of extra notes in the docs - hopefully will save someone else a few minutes of research in the future. 

HTH!
Liz  
