### PR TITLE
Related to https://github.com/flashingpumpkin/django-socialregistration/...

### DIFF
--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -236,7 +236,10 @@ class SetupCallback(SocialRegistration, View):
           form or generate a username automatically
         """
         
-        client = request.session[self.get_client().get_session_key()]
+        try:
+            client = request.session[self.get_client().get_session_key()]
+        except KeyError:
+            return self.render_to_response({'error': "Session expired."})
         
         # Get the lookup dictionary to find the user's profile
         lookup_kwargs = self.get_lookup_kwargs(request, client)


### PR DESCRIPTION
...issues/131. I'm suggesting this change without knowing if this is the proper response (word of warning). I'm getting this error though:

File "/home/getlostmt/.virtualenvs/getlost/myproject/socialregistration/views.py", line 238, in get
   client = request.session[self.get_client().get_session_key()]

 File "/home/getlostmt/.virtualenvs/getlost/lib/python2.7/site-packages/django/contrib/sessions/backends/base.py", line 47, in **getitem**
   return self._session[key]

KeyError: 'socialreg:facebook'

So I figure wrapping it as it was modified in https://github.com/flashingpumpkin/django-socialregistration/commit/7cbc936effc8e2ff885803618654597802c7e2f3 might be a good way to go?
