### PR TITLE
Fixes race condition issue when re-saving facebook access token

### DIFF
--- a/socialregistration/contrib/facebook/models.py
+++ b/socialregistration/contrib/facebook/models.py
@@ -26,12 +26,12 @@ class FacebookAccessToken(models.Model):
 
 def save_facebook_token(sender, user, profile, client, **kwargs):    
     try:
-        FacebookAccessToken.objects.get(profile=profile).delete()
+        access_token = FacebookAccessToken.objects.get(profile=profile)
     except FacebookAccessToken.DoesNotExist:
-        pass
+        access_token = FacebookAccessToken(profile=profile)
     
-    FacebookAccessToken.objects.create(profile=profile,
-        access_token=client.graph.access_token)
+    access_token.access_token = client.graph.access_token
+    access_token.save()
     
 connect.connect(save_facebook_token, sender=FacebookProfile,
     dispatch_uid='socialregistration.facebook.connect')


### PR DESCRIPTION
Hi!

We're spawning a celery task when a user signs in, in order to re-fetch some data from facebook. In this task we use the access token from socialregistration.contrib.facebook. Sometimes we're getting an error because the user doesn't have an access token (even though they've had it on previous sign ins).

I believe this fixes the issue with non existing access tokens (since the delete & insert is replaced with an update if the access token already exists).

There's still a race condition where our task might get the old access token, but that is much less of an issue compared to not getting an access token at all. This could be solved by calling the django.contrib.auth.login() function _after_ the socialregistration.signals.login is triggered. As far as I can tell this change should be OK with the contrib.facebook, but I'm not enough familiar with the code to know if this would break any other services, or any API promises.
