### PR TITLE
fb and openid button tags improved

### DIFF
--- a/socialregistration/contrib/openid/templatetags/openid.py
+++ b/socialregistration/contrib/openid/templatetags/openid.py
@@ -4,10 +4,11 @@ from django import template
 register = template.Library()
 
 @register.inclusion_tag('socialregistration/openid/form.html', takes_context=True)
-def openid_form(context, provider=None, button=None):
+def openid_form(context, provider=None, *params):
+    button = ''.join(params)
     return {
         'provider': provider,
         'button': button,
         'request': context['request']
     }
-    
+

--- a/socialregistration/templatetags/__init__.py
+++ b/socialregistration/templatetags/__init__.py
@@ -3,25 +3,32 @@ from django.utils.translation import ugettext_lazy as _
 
 register = template.Library()
 
-def button(template):
+def button(template_name):
     def tag(parser, token):
         bits = token.split_contents()
-        try:
-            # Is a custom button passed in?
-            return ButtonTag(template, bits[1][1:-1])
-        except IndexError:
+        if len(bits) > 1:
+            return ButtonTag(template_name, *bits[1:])
+        else:
             # No custom button
-            return ButtonTag(template)
+            return ButtonTag(template_name)
     return tag
 
 class ButtonTag(template.Node):
-    def __init__(self, template, button = None):
-        self.template = template
-        self.button = button
-    
+    def __init__(self, template_name, *input):
+        self.template = template_name
+        self.input = input
+
     def render(self, context):
+        output = []
+        for bit in self.input:
+            if not (bit[0] == bit[-1] and bit[0] in ('"', "'")):
+                output.append(template.Variable(bit).resolve(context))
+            else:
+                output.append(bit[1:-1])
+        self.button = ''.join(output)
+
         if not 'request' in context:
             raise AttributeError(_("Please add 'django.core.context_processors.request' "
                 "'to your settings.TEMPLATE_CONTEXT_PROCESSORS'"))
-        
+
         return template.loader.render_to_string(self.template, {'button': self.button, 'next': context.get('next', None)}, context)


### PR DESCRIPTION
Fb and Oid tags can take an arbitrary number of strings and string variables that get concatenated to generate the url to the button image. This was needed in order to not hard-code the static/media urls.
