### PR TITLE
Add third parameter to button template tag

### DIFF
--- a/socialregistration/templatetags/__init__.py
+++ b/socialregistration/templatetags/__init__.py
@@ -3,25 +3,58 @@ from django.utils.translation import ugettext_lazy as _
 
 register = template.Library()
 
+m_template = template
+
+def is_quoted(param):
+    """ Return True parameter has the same kind of quotes in both ends """
+    return (param[0] == param[-1] and param[0] in ('"', "'"))
+
 def button(template):
+    """
+    Button tag takes two optional arguments. The first is a URL pointing
+    to an alternate URL for the button image. The second argument refers
+    to a context variable to be appended before the URL.
+
+    The last argument is useful if a variable (eg. STATIC_URL) defines a
+    URL root that varies between deployments.
+    """
+
     def tag(parser, token):
-        bits = token.split_contents()
-        try:
-            # Is a custom button passed in?
-            return ButtonTag(template, bits[1][1:-1])
-        except IndexError:
-            # No custom button
-            return ButtonTag(template)
+        tokens = token.split_contents()
+        button = None
+        var = None
+
+        token_count = len(tokens)
+
+        if token_count > 3:
+            raise m_template.TemplateSyntaxError("%r tag expects zero to two arguments" % token.contents.split()[0])
+
+        if token_count > 2:
+            param = tokens[1]
+            if not is_quoted(param):
+                raise m_template.TemplateSyntaxError("%r tag's first argument should be quoted" % tokens[0])
+            button = param[1][1:-1]
+
+        if token_count == 3:
+            if is_quoted(tokens[2]):
+                raise m_template.TemplateSyntaxError("%r tag's first argument must be an unquoted template context variable" % tokens[0])
+            var = tokens[2]
+
+        return ButtonTag(template, button, var)
     return tag
 
 class ButtonTag(template.Node):
-    def __init__(self, template, button = None):
+    def __init__(self, template, button=None, var=None):
         self.template = template
         self.button = button
+        self.var = var
     
     def render(self, context):
         if not 'request' in context:
             raise AttributeError(_("Please add 'django.core.context_processors.request' "
                 "'to your settings.TEMPLATE_CONTEXT_PROCESSORS'"))
+
+        if self.var and self.var in context:
+            self.button = str(context.get(var, ''))+self.button
         
         return template.loader.render_to_string(self.template, {'button': self.button, 'next': context.get('next', None)}, context)


### PR DESCRIPTION
Many apps depend on a `STATIC_URL` template variable to prefix the
locations of images to avoid repetition or enable something like a
CDN to be used. There needed to be a way to follow the practice
with socialregistration.

This commit introduces a second optional parameter to the `button`
base template tag. It expects an unquoted context variable and the
contents of that variable will be prepended to the first parameter.
