### PR TITLE
Custom user model finalization

### DIFF
--- a/socialregistration/auth.py
+++ b/socialregistration/auth.py
@@ -1,4 +1,9 @@
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+except ImportError:
+    from django.contrib.auth.models import User
+
 from socialregistration.contrib.facebook.auth import FacebookAuth
 from socialregistration.contrib.linkedin.auth import LinkedInAuth
 from socialregistration.contrib.openid.auth import OpenIDAuth

--- a/socialregistration/contrib/google/models.py
+++ b/socialregistration/contrib/google/models.py
@@ -1,35 +1,40 @@
+from django.conf import settings
 from django.contrib.auth import authenticate
-from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.db import models
 from socialregistration.signals import connect
 
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+
+
 class GoogleProfile(models.Model):
-    user = models.ForeignKey(User, unique=True)
+    user = models.ForeignKey(AUTH_USER_MODEL, unique=True)
     site = models.ForeignKey(Site, default=Site.objects.get_current)
-    google_id = models.CharField(max_length = 255)
+    google_id = models.CharField(max_length=255)
 
     def __unicode__(self):
         try:
             return u'%s: %s' % (self.user, self.google_id)
-        except User.DoesNotExist:
+        except models.ObjectDoesNotExist:
             return u'None'
 
     def authenticate(self):
         return authenticate(google_id=self.google_id)
 
+
 class GoogleAccessToken(models.Model):
     profile = models.OneToOneField(GoogleProfile, related_name='access_token')
     access_token = models.CharField(max_length=255)
+
 
 def save_google_token(sender, user, profile, client, **kwargs):
     try:
         GoogleAccessToken.objects.get(profile=profile).delete()
     except GoogleAccessToken.DoesNotExist:
         pass
-    
-    GoogleAccessToken.objects.create(access_token = client.get_access_token(),
-        profile = profile)
+
+    GoogleAccessToken.objects.create(access_token=client.get_access_token(),
+        profile=profile)
 
 
 connect.connect(save_google_token, sender=GoogleProfile,

--- a/socialregistration/contrib/google/templates/socialregistration/google/google_button.html
+++ b/socialregistration/contrib/google/templates/socialregistration/google/google_button.html
@@ -1,4 +1,5 @@
-<form action="{% url socialregistration:google:redirect %}" method="post">
+{% load url from future %}
+<form action="{% url 'socialregistration:google:redirect' %}" method="post">
     {% csrf_token %}
     {% if next %}
         <input type="hidden" name="next" value="{{ next }}" />

--- a/socialregistration/contrib/google/templates/socialregistration/google/google_button.html
+++ b/socialregistration/contrib/google/templates/socialregistration/google/google_button.html
@@ -1,5 +1,5 @@
 {% load url from future %}
-<form action="{% url 'socialregistration:google:redirect' %}" method="post">
+<form class="connect-button" action="{% url 'socialregistration:google:redirect' %}" method="post">
     {% csrf_token %}
     {% if next %}
         <input type="hidden" name="next" value="{{ next }}" />

--- a/socialregistration/forms.py
+++ b/socialregistration/forms.py
@@ -1,11 +1,16 @@
 from django import forms
 from django.utils.translation import gettext as _
 
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+except ImportError:
+    from django.contrib.auth.models import User
+
 
 class UserForm(forms.Form):
     """
-    Default user creation form. Can be altered with the 
+    Default user creation form. Can be altered with the
     `SOCIALREGISTRATION_SETUP_FORM` setting.
     """
     username = forms.RegexField(r'^\w+$', max_length=32)

--- a/socialregistration/mixins.py
+++ b/socialregistration/mixins.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.contrib.auth import authenticate, login
-from django.contrib.auth.models import User
 from django.http import HttpResponseRedirect
 from django.utils import importlib
 from django.utils.translation import ugettext_lazy as _
@@ -9,8 +8,15 @@ from socialregistration import signals
 from socialregistration.settings import SESSION_KEY
 import urlparse
 
+try:
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+except ImportError:
+    from django.contrib.auth.models import User
+
 ERROR_VIEW = getattr(settings, 'SOCIALREGISTRATION_ERROR_VIEW_FUNCTION',
     None)
+
 
 class CommonMixin(TemplateResponseMixin):
     """

--- a/socialregistration/tests.py
+++ b/socialregistration/tests.py
@@ -1,6 +1,5 @@
 from django import template
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from oauth2 import Client
@@ -8,6 +7,13 @@ from socialregistration.signals import login, connect
 import mock
 import urllib
 import urlparse
+
+try:
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+except ImportError:
+    from django.contrib.auth.models import User
+
 
 class TemplateTagTest(object):
     def get_tag(self):

--- a/socialregistration/utils.py
+++ b/socialregistration/utils.py
@@ -5,3 +5,12 @@ def generate_username(user, profile, client):
     Default function to generate usernames using the built in `uuid` library.
     """
     return str(uuid.uuid4())[:30]
+
+
+def generate_user(request, user, profile, client):
+    """
+    Default function to fill in user attributes
+    """
+    if hasattr(user, "username"):
+        user.username = generate_username(user, profile, client)
+    return user, profile

--- a/socialregistration/views.py
+++ b/socialregistration/views.py
@@ -36,6 +36,7 @@ ALLOW_OPENID_SIGNUPS = getattr(settings, 'SOCIALREGISTRATION_ALLOW_OPENID_SIGNUP
 
 logger = logging.getLogger(__name__)
 
+
 class Setup(SocialRegistration, View):
     """
     Setup view to create new Django users from third party APIs.
@@ -48,18 +49,24 @@ class Setup(SocialRegistration, View):
         with ``SOCIALREGISTRATION_SETUP_FORM``.
         """
         return self.import_attribute(FORM_CLASS)
-    
+
     def get_user_function(self):
         """
-        Return a function that can fill necessary fields in User model.
-        The function have to return tuple (user, profile)
-        The function is controlled with ``SOCIALREGISTRATION_USER_FUNCTION``.
+        Dispatcher of type of user function.
+
+        For SEAMLESS_SETUP it returns a function that can fill necessary fields
+        in User model. The function have to return tuple (user, profile)
+        It is controlled with ``SOCIALREGISTRATION_USER_FUNCTION``.
+
+        For GENERATE_USERNAME it returns a function that produce unique
+        username for the new user. The function have to return string - username
+        It is controlled with ``SOCIALREGISTRATION_GENERATE_USERNAME_FUNCTION``.
         """
         if SEAMLESS_SETUP:
             return self.import_attribute(USER_FUNCTION)
         if GENERATE_USERNAME:
             return self.import_attribute(USERNAME_FUNCTION)
-    
+
     def get_initial_data(self, request, user, profile, client):
         """
         Return initial data for the setup form. The function can be
@@ -94,7 +101,7 @@ class Setup(SocialRegistration, View):
         """
         Fill in user attributes and then redirect the user to the correct place.
         This method is called when ``SOCIALREGISTRATION_SEAMLESS_SETUP`` 
-        is set. 
+        is set.
 
         :param request: The current request object
         :param user: The unsaved user object


### PR DESCRIPTION
Hi, since there usually is not any `username` field  in the custom user model, I propose an update for `GENERATE_USERNAME_FUNCTION` as described in commits. The change is backward compatible and can save some headaches.

There are two new settings variables.

`SOCIALREGISTRATION_USER_FUNCTION` which points to the new-type function. The function fills up necessary fields in the user model and returns tuple: user, profile

`SOCIALREGISTRATION_SEAMLESS_SETUP` is just rename for `SOCIALREGISTRATION_GENERATE_USERNAME` which does not make sense if/when the old function will be removed. Both variables are kept and used as dispatcher.
