### PR TITLE
Fix typo in context processors

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,8 +63,9 @@ Include ``django.core.context_processors.request`` in your TEMPLATE_CONTEXT_PROC
 
 ::
 
-	TEMPLATE_CONTEXT_PROESSORS = (
+	TEMPLATE_CONTEXT_PROCESSORS = (
         'django.core.context_processors.request',
+        'django.contrib.auth.context_processors.auth',
 	)
 
 .. note::


### PR DESCRIPTION
Processors has a 'c' in it.

Also, the auth context processor is necessary.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/flashingpumpkin/django-socialregistration/178)

<!-- Reviewable:end -->
